### PR TITLE
emit with listeners was sending static "value" string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ Editable.prototype._publish = function(value, cb){
   }
 
   var reject = false;
-  self.emit('update', 'value', function(err){
+  self.emit('update', value, function(err){
     if (reject) return;
     if (err) {
       reject = true;


### PR DESCRIPTION
When sending the update event to a given function, the existing _publish function was sending the value as "value" instead of as the actual value typed in.